### PR TITLE
Add Limelight vertical length getter method

### DIFF
--- a/src/main/java/frc/robot/Limelight.java
+++ b/src/main/java/frc/robot/Limelight.java
@@ -15,11 +15,17 @@ public class Limelight {
 
     NetworkTable limelightTable;
 
+    /**
+     * Constructor
+     */
     public Limelight() {
         // Assuming use of the default network table.
         limelightTable = NetworkTableInstance.getDefault().getTable("limelight");
     }
 
+    /**
+     * Updates limelight values.
+     */
     public void update() {
         this.tv = limelightTable.getEntry("tv").getDouble(0);
         this.tx = limelightTable.getEntry("tx").getDouble(0);
@@ -33,22 +39,37 @@ public class Limelight {
         SmartDashboard.putBoolean("LimelightTargeted", this.isTargetVisible());
     }
 
+    /**
+     * @return if target is visible.
+     */
     public boolean isTargetVisible() {
         return this.tv > 0.0;
     }
 
+    /**
+     * @return current target x-coordinate.
+     */
     public double getTargetX() {
         return this.tx;
     }
 
+    /**
+     * @return current target y-coordinate.
+     */
     public double getTargetY() {
         return this.ty;
     }
 
+    /**
+     * @return current target area of screen (0 to 100 percent).
+     */
     public double getTargetArea() {
         return this.ta;
     }
 
+    /**
+     * @return current target vertical length.
+     */
     public double getTargetVertical() {
         return this.tvert;
     }

--- a/src/main/java/frc/robot/Limelight.java
+++ b/src/main/java/frc/robot/Limelight.java
@@ -75,4 +75,7 @@ public class Limelight {
         return this.tvert;
     }
 
+    public void setLightEnabled(boolean enabled) {
+        limelightTable.getEntry("ledMode").forceSetNumber(enabled ? 3: 1);
+    }
 }

--- a/src/main/java/frc/robot/Limelight.java
+++ b/src/main/java/frc/robot/Limelight.java
@@ -37,6 +37,7 @@ public class Limelight {
         SmartDashboard.putNumber("LimelightY", this.getTargetY());
         SmartDashboard.putNumber("LimelightArea", this.getTargetArea());
         SmartDashboard.putBoolean("LimelightTargeted", this.isTargetVisible());
+        SmartDashboard.putNumber("LimelightHeight", this.getTargetVertical());
     }
 
     /**

--- a/src/main/java/frc/robot/Limelight.java
+++ b/src/main/java/frc/robot/Limelight.java
@@ -11,6 +11,7 @@ public class Limelight {
     private double tx;
     private double ty;
     private double ta;
+    private double tvert;
 
     NetworkTable limelightTable;
 
@@ -24,6 +25,7 @@ public class Limelight {
         this.tx = limelightTable.getEntry("tx").getDouble(0);
         this.ty = limelightTable.getEntry("ty").getDouble(0);
         this.ta = limelightTable.getEntry("ta").getDouble(0);
+        this.tvert = limelightTable.getEntry("tvert").getDouble(0);
 
         SmartDashboard.putNumber("LimelightX", this.getTargetX());
         SmartDashboard.putNumber("LimelightY", this.getTargetY());
@@ -46,4 +48,9 @@ public class Limelight {
     public double getTargetArea() {
         return this.ta;
     }
+
+    public double getTargetVertical() {
+        return this.tvert;
+    }
+
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -38,6 +38,9 @@ public class Robot extends TimedRobot {
   public void robotInit() {
     System.out.print("Initializing vision system (limelight)...");
     limelight = new Limelight();
+    limelight.setLightEnabled(false);
+    System.out.println("done");
+
     System.out.print("Initializing shooter...");
     shooter = new Shooter(new CANSparkMax(2, MotorType.kBrushless));
     System.out.println("done");
@@ -74,6 +77,12 @@ public class Robot extends TimedRobot {
     }
 
     shooter.manualControl(speed);
+
+    if (driver.getXButtonPressed()) {
+      limelight.setLightEnabled(true);
+    } else if (driver.getYButtonPressed()) {
+      limelight.setLightEnabled(false);
+    }
 
     SmartDashboard.putNumber("ShooterPower", speed);
     SmartDashboard.putNumber("ShooterRPM", shooter.getLauncherRPM());


### PR DESCRIPTION
Adds a getter method for the limelight for the vertical length of the target. Used to judge the distance of the vision target.