### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2020.1.2"
+    id "edu.wpi.first.GradleRIO" version "2020.2.2"
 }
 
 sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
Bump the Gradle plugin `edu.wpi.first.GradleRIO` from `2020.1.2` to `2020.2.2`

This should probably be tested. Only a suggestion though.