### PR TITLE
Add Drivetrain Sweeping

### DIFF
--- a/src/main/java/frc/robot/Drivetrain.java
+++ b/src/main/java/frc/robot/Drivetrain.java
@@ -34,7 +34,7 @@ public class Drivetrain {
      * @param right The right drive module
      * @param detector The powercell detection object.
      */
-    Drivetrain(DriveModule left, DriveModule right, PowercellDetection detector, Limelight limelight, AHRS gyro){
+    Drivetrain(DriveModule left, DriveModule right, PowercellDetection detector, AHRS gyro){
         this.left = left;
         this.right = right;
         left.setInverted(true);
@@ -136,10 +136,10 @@ public class Drivetrain {
     }
 
     /**
-     * Sweeps to the left 80 degrees.
+     * Sweeps to the left 45 degrees.
      */
     private void sweepLeft() {
-        if (gyro.getAngle() < gyroAngle + 80) {
+        if (gyro.getAngle() < gyroAngle + 45) {
             driveLeft(-0.50);
             driveRight(0.50);
         } else {
@@ -148,11 +148,11 @@ public class Drivetrain {
     }
 
     /**
-     * Sweeps to the right 80 degrees.
+     * Sweeps to the right 45 degrees.
 
      */
     private void sweepRight() {
-        if (gyro.getAngle() > gyroAngle - 80) {
+        if (gyro.getAngle() > gyroAngle - 45) {
             driveLeft(0.50);
             driveRight(-0.50);
         } else {

--- a/src/main/java/frc/robot/Drivetrain.java
+++ b/src/main/java/frc/robot/Drivetrain.java
@@ -1,5 +1,7 @@
 package frc.robot;
 
+import com.kauailabs.navx.frc.AHRS;
+
 public class Drivetrain {
     
     /**
@@ -8,9 +10,22 @@ public class Drivetrain {
      */
     private static final double DEADBAND_LIMIT = 0.02;
 
+    private enum SweepState {
+        SET_ANGLE,
+        SWEEP_LEFT,
+        SWEEP_RIGHT,
+        IDLE;
+    }
+
+    private SweepState sweepState;
+
     private DriveModule left;
     private DriveModule right;
     private PowercellDetection detector;
+    private Limelight limelight;
+    private AHRS gyro;
+
+    private double gyroAngle;
 
     /**
      * Constructor
@@ -19,12 +34,16 @@ public class Drivetrain {
      * @param right The right drive module
      * @param detector The powercell detection object.
      */
-    Drivetrain(DriveModule left, DriveModule right, PowercellDetection detector){
+    Drivetrain(DriveModule left, DriveModule right, PowercellDetection detector, Limelight limelight, AHRS gyro){
         this.left = left;
         this.right = right;
         left.setInverted(true);
 
         this.detector = detector;
+        this.limelight = limelight;
+        this.gyro = gyro;
+
+        sweepState = SweepState.IDLE;
     }
 
     /**
@@ -83,6 +102,63 @@ public class Drivetrain {
      */
     public double deadband(double in) {
         return Math.abs(in) > DEADBAND_LIMIT ? in : 0.0;
+    }
+
+    /**
+     * Runs the sweeping procedure.
+     */
+    public void sweep() {
+        switch(sweepState) {
+            
+            case SET_ANGLE:
+                sweepAngle();
+                break;
+
+            case SWEEP_LEFT:
+                sweepLeft();
+                break;
+
+            case SWEEP_RIGHT:
+                sweepRight();
+                break;
+
+            case IDLE:
+                break;
+        }
+    }
+
+    /**
+     * Sets home gyro angle.
+     */
+    private void sweepAngle() {
+        gyroAngle = gyro.getAngle();
+        sweepState = SweepState.SWEEP_LEFT;
+    }
+
+    /**
+     * Sweeps to the left 80 degrees.
+     */
+    private void sweepLeft() {
+        if (gyro.getAngle() < gyroAngle + 80) {
+            driveLeft(-0.50);
+            driveRight(0.50);
+        } else {
+            sweepState = SweepState.SWEEP_RIGHT;
+        }
+    }
+
+    /**
+     * Sweeps to the right 80 degrees.
+
+     */
+    private void sweepRight() {
+        if (gyro.getAngle() > gyroAngle - 80) {
+            driveLeft(0.50);
+            driveRight(-0.50);
+        } else {
+            sweepState = SweepState.SWEEP_LEFT;
+        }
+
     }
 
     /**

--- a/src/main/java/frc/robot/Drivetrain.java
+++ b/src/main/java/frc/robot/Drivetrain.java
@@ -158,7 +158,20 @@ public class Drivetrain {
         } else {
             sweepState = SweepState.SWEEP_LEFT;
         }
+    }
 
+    /**
+     * Resets to the state to setting the angle.
+     */
+    public void resetState() {
+        sweepState = SweepState.SET_ANGLE;
+    }
+
+    /**
+     * Sets the state to idle.
+     */
+    public void stopSweep() {
+        sweepState = SweepState.IDLE;
     }
 
     /**

--- a/src/main/java/frc/robot/Drivetrain.java
+++ b/src/main/java/frc/robot/Drivetrain.java
@@ -180,8 +180,16 @@ public class Drivetrain {
      * @param x target X-coordinate
      */
     public void approachPC(double x) {
-        //TODO: Determine division variable for percent of screen
-        driveLeft(x >= 0 ? 0.75 : (0.75 * (detector.getTarget(0).getInvertedAreaPercent()/4)));
-        driveRight(x <= 0 ? 0.75 : (0.75 * (detector.getTarget(0).getInvertedAreaPercent()/4)));
+        if (detector.getNumber() != 0) {
+            stopSweep();
+            //TODO: Determine division variable for percent of screen
+            driveLeft(x >= 0 ? 0.75 : (0.75 * (detector.getTarget(0).getInvertedAreaPercent()/4)));
+            driveRight(x <= 0 ? 0.75 : (0.75 * (detector.getTarget(0).getInvertedAreaPercent()/4)));
+        } else {
+            if (sweepState == SweepState.IDLE) {
+                resetState();
+            }
+            sweep();
+        }
     }
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -104,7 +104,7 @@ public class Robot extends TimedRobot {
       System.out.print("Initializing drivetrain...");
       DriveModule leftModule = new DriveModule(new TalonFX(5), new TalonFX(6), new TalonFX(7), new Solenoid(2, 0));
       DriveModule rightModule = new DriveModule(new TalonFX(8), new TalonFX(9), new TalonFX(10), new Solenoid(2, 1));
-      drive = new Drivetrain(leftModule, rightModule, detector);
+      drive = new Drivetrain(leftModule, rightModule, detector, limelight, gyro);
       System.out.println("done");
     } else {
       System.out.println("Drivetrain disabled. Skipping initialization...");

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -104,7 +104,7 @@ public class Robot extends TimedRobot {
       System.out.print("Initializing drivetrain...");
       DriveModule leftModule = new DriveModule(new TalonFX(5), new TalonFX(6), new TalonFX(7), new Solenoid(2, 0));
       DriveModule rightModule = new DriveModule(new TalonFX(8), new TalonFX(9), new TalonFX(10), new Solenoid(2, 1));
-      drive = new Drivetrain(leftModule, rightModule, detector, limelight, gyro);
+      drive = new Drivetrain(leftModule, rightModule, detector, gyro);
       System.out.println("done");
     } else {
       System.out.println("Drivetrain disabled. Skipping initialization...");


### PR DESCRIPTION
Sweeps the robot side to side if it can't see its target (limelight or powercell detection).